### PR TITLE
Refactor

### DIFF
--- a/src/main/java/com/thompson/bullrun/common/BufferingClientHttpResponseWrapper.java
+++ b/src/main/java/com/thompson/bullrun/common/BufferingClientHttpResponseWrapper.java
@@ -1,5 +1,7 @@
 package com.thompson.bullrun.common;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.StreamUtils;
 
@@ -23,8 +25,8 @@ public class BufferingClientHttpResponseWrapper implements ClientHttpResponse {
     }
 
     @Override
-    public int getRawStatusCode() throws IOException {
-        return response.getRawStatusCode();
+    public HttpStatus getStatusCode() throws IOException {
+        return (HttpStatus) response.getStatusCode();
     }
 
     @Override
@@ -33,17 +35,12 @@ public class BufferingClientHttpResponseWrapper implements ClientHttpResponse {
     }
 
     @Override
+    public HttpHeaders getHeaders() {
+        return response.getHeaders();
+    }
+
+    @Override
     public void close() {
         response.close();
-    }
-
-    @Override
-    public org.springframework.http.HttpStatus getStatusCode() throws IOException {
-        return (org.springframework.http.HttpStatus) response.getStatusCode();
-    }
-
-    @Override
-    public org.springframework.http.HttpHeaders getHeaders() {
-        return response.getHeaders();
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `BufferingClientHttpResponseWrapper` class in order to improve the handling of HTTP responses. The most important changes include importing additional classes from the `org.springframework.http` package, modifying the return type of the `getStatusCode` method, and reordering methods for better code organization.

Improvements to HTTP response handling:

* [`src/main/java/com/thompson/bullrun/common/BufferingClientHttpResponseWrapper.java`](diffhunk://#diff-296bed45b8b73b2b0c7e1b2822b1e55104fe7225fcc02811ee2880fe03f82360R3-R4): Imported `HttpHeaders` and `HttpStatus` from `org.springframework.http` package to enhance HTTP response handling.
* [`src/main/java/com/thompson/bullrun/common/BufferingClientHttpResponseWrapper.java`](diffhunk://#diff-296bed45b8b73b2b0c7e1b2822b1e55104fe7225fcc02811ee2880fe03f82360L26-R29): Changed the return type of the `getStatusCode` method from `int` to `HttpStatus` to provide more meaningful status information.
* [`src/main/java/com/thompson/bullrun/common/BufferingClientHttpResponseWrapper.java`](diffhunk://#diff-296bed45b8b73b2b0c7e1b2822b1e55104fe7225fcc02811ee2880fe03f82360L36-R44): Reordered methods to improve code organization, ensuring `getHeaders` and `close` methods follow a logical sequence.