### PR TITLE
Updated platform image

### DIFF
--- a/.github/workflows/gradle-build-and-docker-push.yml.yaml
+++ b/.github/workflows/gradle-build-and-docker-push.yml.yaml
@@ -36,8 +36,8 @@ jobs:
       # Build Docker image
       - name: Build Docker Image
         run: |
-          docker build -t ${{ secrets.DOCKER_USERNAME }}/bullrun-service .
-
+          docker build --platform linux/amd64 -t ${{ secrets.DOCKER_USERNAME }}/bullrun-service .
+      
       # Push Docker image to Docker Hub
       - name: Push Docker Image
         run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/gradle-build-and-docker-push.yml.yaml` file. The change specifies the platform as `linux/amd64` when building the Docker image.

* [`.github/workflows/gradle-build-and-docker-push.yml.yaml`](diffhunk://#diff-7a6444b3e83c01597c3b402bdb86c52b1b57cc6e9e4bca211938f2929ed24041L39-R39): Modified the Docker build command to include the `--platform linux/amd64` option.