### PR TITLE
Updated platform image

### DIFF
--- a/.github/workflows/gradle-build-and-docker-push.yml.yaml
+++ b/.github/workflows/gradle-build-and-docker-push.yml.yaml
@@ -36,8 +36,8 @@ jobs:
       # Build Docker image
       - name: Build Docker Image
         run: |
-          docker build --platform linux/amd64 -t ${{ secrets.DOCKER_USERNAME }}/bullrun-service .
-      
+          docker build --platform linux/arm64/v8 -t ${{ secrets.DOCKER_USERNAME }}/bullrun-service .
+
       # Push Docker image to Docker Hub
       - name: Push Docker Image
         run: |


### PR DESCRIPTION
This pull request includes a change to the Docker image build process in the GitHub Actions workflow file. The platform for the Docker build has been updated to target `linux/arm64/v8` instead of `linux/amd64`.

Changes to Docker build process:

* [`.github/workflows/gradle-build-and-docker-push.yml.yaml`](diffhunk://#diff-7a6444b3e83c01597c3b402bdb86c52b1b57cc6e9e4bca211938f2929ed24041L39-R39): Updated the Docker platform from `linux/amd64` to `linux/arm64/v8` in the `Build Docker Image` step.