### PR TITLE
Removed inject steps for security reasons.

### DIFF
--- a/.github/workflows/gradle-build-and-docker-push.yml.yaml
+++ b/.github/workflows/gradle-build-and-docker-push.yml.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - dev
 
 jobs:
   build-and-push:
@@ -23,21 +22,8 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      # Inject secrets into application.properties (Dynamic configuration)
-      - name: Inject Secrets into application.properties
-        run: |
-          sed -i "s|twelveDataAPIKey=.*|twelveDataAPIKey=${{ secrets.TWELVE_DATA_API_KEY }}|g" src/main/resources/application.properties
-          sed -i "s|polygonAPIKey=.*|polygonAPIKey=${{ secrets.POLYGON_API_KEY }}|g" src/main/resources/application.properties
-          sed -i "s|spring.data.mongodb.uri=.*|spring.data.mongodb.uri=${{ secrets.MONGODB_URI }}|g" src/main/resources/application.properties
-          sed -i "s|spring.data.mongodb.database=.*|spring.data.mongodb.database=${{ secrets.MONGODB_DATABASE }}|g" src/main/resources/application.properties
-
       # Build the app with Gradle
       - name: Build with Gradle
-        env:
-          TWELVE_DATA_API_KEY: ${{ secrets.TWELVE_DATA_API_KEY }}
-          POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}
-          MONGODB_URI: ${{ secrets.MONGODB_URI }}
-          MONGODB_DATABASE: ${{ secrets.MONGODB_DATABASE }}
         run: ./gradlew build
 
       # Log in to Docker Hub
@@ -47,11 +33,10 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # Build Docker Image
+      # Build Docker image
       - name: Build Docker Image
         run: |
-          docker build --platform linux/arm64/v8 \
-                       -t ${{ secrets.DOCKER_USERNAME }}/bullrun-service .
+          docker build --platform linux/arm64/v8 -t ${{ secrets.DOCKER_USERNAME }}/bullrun-service .
 
       # Push Docker image to Docker Hub
       - name: Push Docker Image

--- a/.github/workflows/gradle-build-and-docker-push.yml.yaml
+++ b/.github/workflows/gradle-build-and-docker-push.yml.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dev
 
 jobs:
   build-and-push:
@@ -46,10 +47,13 @@ jobs:
           sed -i "s|\${MONGODB_URI}|${{ secrets.MONGODB_URI }}|g" src/main/resources/application.properties
           sed -i "s|\${MONGODB_DATABASE}|${{ secrets.MONGODB_DATABASE }}|g" src/main/resources/application.properties
 
-      # Build Docker image
       - name: Build Docker Image
         run: |
           docker build --platform linux/arm64/v8 \
+                       --build-arg TWELVE_DATA_API_KEY=${{ secrets.TWELVE_DATA_API_KEY }} \
+                       --build-arg POLYGON_API_KEY=${{ secrets.POLYGON_API_KEY }} \
+                       --build-arg MONGODB_URI=${{ secrets.MONGODB_URI }} \
+                       --build-arg MONGODB_DATABASE=${{ secrets.MONGODB_DATABASE }} \
                        -t ${{ secrets.DOCKER_USERNAME }}/bullrun-service .
 
       # Push Docker image to Docker Hub

--- a/.github/workflows/gradle-build-and-docker-push.yml.yaml
+++ b/.github/workflows/gradle-build-and-docker-push.yml.yaml
@@ -39,21 +39,18 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # Inject application.properties secrets (if needed)
+      # Inject secrets into application.properties (Dynamic configuration)
       - name: Inject Secrets into application.properties
         run: |
-          sed -i "s|\${TWELVE_DATA_API_KEY}|${{ secrets.TWELVE_DATA_API_KEY }}|g" src/main/resources/application.properties
-          sed -i "s|\${POLYGON_API_KEY}|${{ secrets.POLYGON_API_KEY }}|g" src/main/resources/application.properties
-          sed -i "s|\${MONGODB_URI}|${{ secrets.MONGODB_URI }}|g" src/main/resources/application.properties
-          sed -i "s|\${MONGODB_DATABASE}|${{ secrets.MONGODB_DATABASE }}|g" src/main/resources/application.properties
+          sed -i "s|twelveDataAPIKey=.*|twelveDataAPIKey=${{ secrets.TWELVE_DATA_API_KEY }}|g" src/main/resources/application.properties
+          sed -i "s|polygonAPIKey=.*|polygonAPIKey=${{ secrets.POLYGON_API_KEY }}|g" src/main/resources/application.properties
+          sed -i "s|spring.data.mongodb.uri=.*|spring.data.mongodb.uri=${{ secrets.MONGODB_URI }}|g" src/main/resources/application.properties
+          sed -i "s|spring.data.mongodb.database=.*|spring.data.mongodb.database=${{ secrets.MONGODB_DATABASE }}|g" src/main/resources/application.properties
 
+      # Build Docker Image
       - name: Build Docker Image
         run: |
           docker build --platform linux/arm64/v8 \
-                       --build-arg TWELVE_DATA_API_KEY=${{ secrets.TWELVE_DATA_API_KEY }} \
-                       --build-arg POLYGON_API_KEY=${{ secrets.POLYGON_API_KEY }} \
-                       --build-arg MONGODB_URI=${{ secrets.MONGODB_URI }} \
-                       --build-arg MONGODB_DATABASE=${{ secrets.MONGODB_DATABASE }} \
                        -t ${{ secrets.DOCKER_USERNAME }}/bullrun-service .
 
       # Push Docker image to Docker Hub

--- a/.github/workflows/gradle-build-and-docker-push.yml.yaml
+++ b/.github/workflows/gradle-build-and-docker-push.yml.yaml
@@ -23,6 +23,14 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
+      # Inject secrets into application.properties (Dynamic configuration)
+      - name: Inject Secrets into application.properties
+        run: |
+          sed -i "s|twelveDataAPIKey=.*|twelveDataAPIKey=${{ secrets.TWELVE_DATA_API_KEY }}|g" src/main/resources/application.properties
+          sed -i "s|polygonAPIKey=.*|polygonAPIKey=${{ secrets.POLYGON_API_KEY }}|g" src/main/resources/application.properties
+          sed -i "s|spring.data.mongodb.uri=.*|spring.data.mongodb.uri=${{ secrets.MONGODB_URI }}|g" src/main/resources/application.properties
+          sed -i "s|spring.data.mongodb.database=.*|spring.data.mongodb.database=${{ secrets.MONGODB_DATABASE }}|g" src/main/resources/application.properties
+
       # Build the app with Gradle
       - name: Build with Gradle
         env:
@@ -38,14 +46,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      # Inject secrets into application.properties (Dynamic configuration)
-      - name: Inject Secrets into application.properties
-        run: |
-          sed -i "s|twelveDataAPIKey=.*|twelveDataAPIKey=${{ secrets.TWELVE_DATA_API_KEY }}|g" src/main/resources/application.properties
-          sed -i "s|polygonAPIKey=.*|polygonAPIKey=${{ secrets.POLYGON_API_KEY }}|g" src/main/resources/application.properties
-          sed -i "s|spring.data.mongodb.uri=.*|spring.data.mongodb.uri=${{ secrets.MONGODB_URI }}|g" src/main/resources/application.properties
-          sed -i "s|spring.data.mongodb.database=.*|spring.data.mongodb.database=${{ secrets.MONGODB_DATABASE }}|g" src/main/resources/application.properties
 
       # Build Docker Image
       - name: Build Docker Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,19 +13,6 @@ EXPOSE 8080
 # Command to run the jar file
 ENTRYPOINT ["java", "-jar", "app.jar"]
 
-# Use build arguments
-ARG TWELVE_DATA_API_KEY
-ARG POLYGON_API_KEY
-ARG MONGODB_URI
-ARG MONGODB_DATABASE
-
-# Set as environment variables in the image
-ENV TWELVE_DATA_API_KEY=${TWELVE_DATA_API_KEY}
-ENV POLYGON_API_KEY=${POLYGON_API_KEY}
-ENV MONGODB_URI=${MONGODB_URI}
-ENV MONGODB_DATABASE=${MONGODB_DATABASE}
-
-
 # Health check to monitor the application
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD curl -f http://localhost:8080/actuator/health || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,19 @@ EXPOSE 8080
 # Command to run the jar file
 ENTRYPOINT ["java", "-jar", "app.jar"]
 
+# Use build arguments
+ARG TWELVE_DATA_API_KEY
+ARG POLYGON_API_KEY
+ARG MONGODB_URI
+ARG MONGODB_DATABASE
+
+# Set as environment variables in the image
+ENV TWELVE_DATA_API_KEY=${TWELVE_DATA_API_KEY}
+ENV POLYGON_API_KEY=${POLYGON_API_KEY}
+ENV MONGODB_URI=${MONGODB_URI}
+ENV MONGODB_DATABASE=${MONGODB_DATABASE}
+
+
 # Health check to monitor the application
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD curl -f http://localhost:8080/actuator/health || exit 1


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/gradle-build-and-docker-push.yml.yaml` file, focusing on the removal of secret environment variables and the simplification of the Docker build command.

Changes to GitHub Actions workflow:

* Removed the environment variables `TWELVE_DATA_API_KEY`, `POLYGON_API_KEY`, `MONGODB_URI`, and `MONGODB_DATABASE` from the Gradle build step.
* Removed the step to inject secrets into `application.properties`.
* Simplified the Docker build command by removing unnecessary line breaks.